### PR TITLE
Fix(fielsd_name): Field names from ClassName shouldn't include "CP_"

### DIFF
--- a/Pardot Forms/Native Pardot page/Step_1.html
+++ b/Pardot Forms/Native Pardot page/Step_1.html
@@ -123,7 +123,7 @@
     var field_classes = className.split(" ").filter((value) => !["", "form-field", "pd-hidden", "hidden"].includes(value));
     for (var i in field_classes) {
       if (field_classes[i].includes("CP_")) {
-        return field_classes[i];
+        return field_classes[i].replace("CP_", "");
       }
     }
     return undefined;


### PR DESCRIPTION
Field names from class name are starting with "CP_". But, the field names in the request to server shouldn't include the "CP_".

Other wise the form data won't match with server fields and the email that Chilipiper sends to assignees won't contain the user data.